### PR TITLE
Support chain start

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,3 +1,4 @@
+import './load-env.js';
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
 import { typeDefs } from './schema.js';

--- a/backend/load-env.js
+++ b/backend/load-env.js
@@ -1,0 +1,5 @@
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+dotenv.config({ path: join(dirname(fileURLToPath(import.meta.url)), '.env') });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@prisma/client": "^6.19.2",
         "apollo-server-express": "^3.13.0",
         "bcrypt": "^6.0.0",
+        "dotenv": "^16.6.1",
         "graphql": "^16.10.0",
         "jsonwebtoken": "^9.0.3",
         "react-router-dom": "^7.13.0"
@@ -1471,7 +1472,6 @@
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
       "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -1604,6 +1604,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1829,6 +1830,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.10.0.tgz",
       "integrity": "sha512-AjqGKbDGUFRKIRCP9tCKiIGHyriz2oHEbPIbEtcSLSs4YjReZOIPQQWek4+6hjw62H9QShXHyaGivGiYVLeYFQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -2372,6 +2374,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -2627,8 +2630,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,10 +17,11 @@
     "@apollo/server": "^4.12.0",
     "@prisma/client": "^6.19.2",
     "apollo-server-express": "^3.13.0",
-    "graphql": "^16.10.0",
-    "react-router-dom": "^7.13.0",
     "bcrypt": "^6.0.0",
-    "jsonwebtoken": "^9.0.3"
+    "dotenv": "^16.6.1",
+    "graphql": "^16.10.0",
+    "jsonwebtoken": "^9.0.3",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "prisma": "^6.19.2"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model User {

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -1,4 +1,5 @@
 // prisma/seed.js
+import '../load-env.js';
 import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcrypt';
 

--- a/frontend/src/components/NodeConnectionLines.tsx
+++ b/frontend/src/components/NodeConnectionLines.tsx
@@ -1,0 +1,69 @@
+import { useLayoutEffect, useRef } from 'react';
+import * as THREE from 'three';
+import { useFrame } from '@react-three/fiber';
+import { PhysicsNode } from '../pages/TestPageStuff/TestClasses';
+
+const EDGE_COLOR = '#64748b';
+const EDGE_OPACITY = 0.55;
+
+/**
+ * Renders each graph edge once (undirected) using current node positions.
+ */
+export function NodeConnectionLines({ nodes }: { nodes: PhysicsNode[] }) {
+    const geomRef = useRef<THREE.BufferGeometry>(null);
+
+    useLayoutEffect(() => {
+        const geom = geomRef.current;
+        if (!geom) {
+            return;
+        }
+        geom.setAttribute(
+            'position',
+            new THREE.Float32BufferAttribute(new Float32Array([0, 0, 0, 0, 0, 0]), 3)
+        );
+        geom.setDrawRange(0, 0);
+    }, []);
+
+    useFrame(() => {
+        const geom = geomRef.current;
+        if (!geom) {
+            return;
+        }
+
+        const coords: number[] = [];
+        for (let i = 0; i < nodes.length; i++) {
+            const node = nodes[i];
+            for (const neighbor of node.neighbors) {
+                const j = nodes.indexOf(neighbor);
+                if (j === -1 || i >= j) {
+                    continue;
+                }
+                coords.push(node.x, node.y, node.z, neighbor.x, neighbor.y, neighbor.z);
+            }
+        }
+
+        const count = coords.length / 3;
+        if (count === 0) {
+            geom.setDrawRange(0, 0);
+            return;
+        }
+
+        const attr = new THREE.Float32BufferAttribute(new Float32Array(coords), 3);
+        geom.setAttribute('position', attr);
+        geom.setDrawRange(0, count);
+        geom.computeBoundingSphere();
+    });
+
+    return (
+        <lineSegments frustumCulled={false} renderOrder={-1}>
+            <bufferGeometry ref={geomRef} />
+            <lineBasicMaterial
+                color={EDGE_COLOR}
+                transparent
+                opacity={EDGE_OPACITY}
+                depthTest
+                depthWrite={false}
+            />
+        </lineSegments>
+    );
+}

--- a/frontend/src/components/PhysicsPatternView.tsx
+++ b/frontend/src/components/PhysicsPatternView.tsx
@@ -3,26 +3,37 @@ import { Canvas, useFrame } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import { PhysicsNode } from '../pages/TestPageStuff/TestClasses';
 import { useSpringSimulation } from '../pages/TestPageStuff/useSpringSimulation';
+import { NodeConnectionLines } from './NodeConnectionLines';
 import { ThreeModel } from './ThreeModel';
 import { ColoredPoints } from '../utilities/types';
 import { nodesToColoredPoints } from '../utilities/converters';
 import styles from './ThreeCanvas.module.css';
 
+/** Off by default. Set `VITE_DEBUG_PATTERN_VIEW=true` in `.env.local` for graph edges and smaller spheres. */
+const DEBUG_PATTERN_VIEW_DEFAULT = import.meta.env.VITE_DEBUG_PATTERN_VIEW === 'true';
+
 interface PhysicsPatternViewProps {
     nodes: PhysicsNode[];
+    /** Graph edges + small spheres for inspection. */
+    debug?: boolean;
 }
 
 const DEFAULT_SIZE = 50;
 const FOV = 75;
 
 // Component that runs inside Canvas to convert nodes to ColoredPoints on each frame
-const PhysicsPatternModel = ({ nodes }: { nodes: PhysicsNode[] }) => {
+const PhysicsPatternModel = ({
+    nodes,
+    debugPreview,
+}: {
+    nodes: PhysicsNode[];
+    debugPreview: boolean;
+}) => {
     const [points, setPoints] = useState<ColoredPoints[]>(() => {
         return nodesToColoredPoints(nodes);
     });
 
-    // Run physics simulation (faster with increased dt)
-    useSpringSimulation({ nodes, dt: 0.08 });
+    useSpringSimulation({ nodes });
 
     // Update points on each frame
     useFrame(() => {
@@ -30,11 +41,17 @@ const PhysicsPatternModel = ({ nodes }: { nodes: PhysicsNode[] }) => {
     });
     
     return (
-        <ThreeModel transformedPattern={{ patternPoints: points }} />
+        <>
+            {debugPreview ? <NodeConnectionLines nodes={nodes} /> : null}
+            <ThreeModel transformedPattern={{ patternPoints: points }} debugPreview={debugPreview} />
+        </>
     );
 };
 
-export const PhysicsPatternView = ({ nodes }: PhysicsPatternViewProps) => {
+export const PhysicsPatternView = ({
+    nodes,
+    debug = DEBUG_PATTERN_VIEW_DEFAULT,
+}: PhysicsPatternViewProps) => {
     return (
         <div className={styles.canvasContainer}>
             <div className={styles.canvasControls}>
@@ -64,7 +81,7 @@ export const PhysicsPatternView = ({ nodes }: PhysicsPatternViewProps) => {
                 <axesHelper args={[DEFAULT_SIZE]} />
                 
                 {/* Physics simulation and rendering */}
-                <PhysicsPatternModel nodes={nodes} />
+                <PhysicsPatternModel nodes={nodes} debugPreview={debug} />
                 
                 {/* Enhanced camera controls */}
                 <OrbitControls 

--- a/frontend/src/components/ThreeModel.tsx
+++ b/frontend/src/components/ThreeModel.tsx
@@ -1,11 +1,23 @@
 import * as THREE from 'three'
 import { TransformedPattern } from '../utilities/types';
 
-const SPHERE_RADIUS = 2.50;
+const SPHERE_RADIUS_DEFAULT = 2.5;
+/** Smaller spheres when debug preview is on (dense graphs, inspection). */
+const SPHERE_RADIUS_DEBUG = 0.65;
 const SPHERE_SEGMENTS = 32;
 const SHADOW_SCALE = 1.05;
 
-export const ThreeModel = ({transformedPattern}: {transformedPattern: TransformedPattern}) => {
+type ThreeModelProps = {
+    transformedPattern: TransformedPattern;
+    /** Smaller stitch spheres — enable via pattern preview debug (off by default). */
+    debugPreview?: boolean;
+};
+
+export const ThreeModel = ({
+    transformedPattern,
+    debugPreview = false,
+}: ThreeModelProps) => {
+    const sphereRadius = debugPreview ? SPHERE_RADIUS_DEBUG : SPHERE_RADIUS_DEFAULT;
     const { patternPoints, transform } = transformedPattern;
     const { x, y, z, rotX, rotY, rotZ } = transform || { x: 0, y: 0, z: 0, rotX: 0, rotY: 0, rotZ: 0 };
 
@@ -31,7 +43,7 @@ export const ThreeModel = ({transformedPattern}: {transformedPattern: Transforme
                                 position={new THREE.Vector3(...point)}
                                 receiveShadow
                             >
-                                <sphereGeometry args={[SPHERE_RADIUS, SPHERE_SEGMENTS, SPHERE_SEGMENTS]} />
+                                <sphereGeometry args={[sphereRadius, SPHERE_SEGMENTS, SPHERE_SEGMENTS]} />
                                 <meshStandardMaterial 
                                     color={color === "black" ? "#2a2a2a" : "#e5e5e5"} 
                                     side={THREE.BackSide}
@@ -47,7 +59,7 @@ export const ThreeModel = ({transformedPattern}: {transformedPattern: Transforme
                                 castShadow
                                 receiveShadow
                             >
-                                <sphereGeometry args={[SPHERE_RADIUS, SPHERE_SEGMENTS, SPHERE_SEGMENTS]} />
+                                <sphereGeometry args={[sphereRadius, SPHERE_SEGMENTS, SPHERE_SEGMENTS]} />
                                 <meshStandardMaterial 
                                     color={color}
                                     roughness={0.85}

--- a/frontend/src/data/samplePatterns.ts
+++ b/frontend/src/data/samplePatterns.ts
@@ -1,0 +1,113 @@
+export type SamplePattern = {
+    id: string;
+    label: string;
+    text: string;
+};
+
+/** Short sample patterns that match the parser in `utilities/parser.ts`. */
+export const SAMPLE_PATTERNS: SamplePattern[] = [
+    {
+        id: "sphere-test-series",
+        label: "Sphere in Spiral",
+        text: `#FF0000
+            mr6
+            incx6
+            (sc,inc) x 6
+            (scx2,inc) x 6
+            (scx3,inc) x 6
+            scx30
+            scx30
+            scx30
+            scx30
+            scx30
+            (scx3,dec) x 6
+            (scx2,dec) x 6
+            (sc,dec) x 6
+            decx6`,
+    },
+    {
+        id: "tube",
+        label: "Long Tube",
+        text: `#00FF00
+            mr6
+            incx6
+            (sc,inc) x 6
+            (scx2,inc) x 6
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24
+            scx24`,
+    },
+    {
+        id: "pouch",
+        label: "Open Pouch",
+        text: `#0000FF
+            ch10
+            (scx8,inc) x 2
+            scx20
+            scx20
+            scx20
+            scx20
+            scx20`,
+    },
+    {
+        id: "trapezoid",
+        label: "Trapezoid",
+        text: `#FFFF00
+            ch6
+            inc,scx4,inc
+            scx8
+            inc,scx6,inc
+            scx10
+            inc,scx8,inc
+            scx12`,
+    },
+    {
+        id: "circle",
+        label: "Circle in Rows",
+        text: `#00FFFF
+            ch5
+            inc,inc,sc,inc,inc
+            inc,scx7,inc
+            inc,scx9,inc
+            scx13
+            scx13
+            scx13
+            scx13
+            dec,scx9,dec
+            dec,scx7,dec
+            dec,dec,sc,dec,dec`,
+    },
+    {
+        id: "square",
+        label: "Square in Rows",
+        text: `#FF00FF
+            ch12
+            scx12
+            scx12
+            scx12
+            scx12
+            scx12
+            scx12
+            scx12
+            scx12
+            scx12
+            scx12`,
+    },
+    {
+        id: "rectangle-spiral",
+        label: "Rectangle in Spiral",
+        text: `#000000
+            ch6
+            scx4, inc3, scx4, inc3
+            (scx4, inc3, sc, inc3) x2
+            (scx8, inc3, sc, inc3) x2`,
+    },
+];

--- a/frontend/src/data/samplePatterns.ts
+++ b/frontend/src/data/samplePatterns.ts
@@ -27,7 +27,7 @@ export const SAMPLE_PATTERNS: SamplePattern[] = [
     },
     {
         id: "tube",
-        label: "Long Tube",
+        label: "Closed Tube",
         text: `#00FF00
             mr6
             incx6
@@ -104,10 +104,10 @@ export const SAMPLE_PATTERNS: SamplePattern[] = [
     {
         id: "rectangle-spiral",
         label: "Rectangle in Spiral",
-        text: `#000000
+        text: `#AAAAAA
             ch6
             scx4, inc3, scx4, inc3
             (scx4, inc3, sc, inc3) x2
-            (scx8, inc3, sc, inc3) x2`,
+            (scx5, inc3, scx3, inc3, sc) x2`,
     },
 ];

--- a/frontend/src/pages/PatternPage.module.css
+++ b/frontend/src/pages/PatternPage.module.css
@@ -91,6 +91,41 @@
   display: block;
 }
 
+.patternInputHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.patternInputHeader .inputLabel {
+  margin-bottom: 0;
+}
+
+.samplePatternTools {
+  flex-shrink: 0;
+}
+
+.sampleSelect {
+  font-size: var(--font-size-sm);
+  padding: var(--space-sm) var(--space-md);
+  border: 2px solid var(--neutral-300);
+  border-radius: var(--radius-md);
+  background: white;
+  color: var(--neutral-800);
+  min-width: 14rem;
+  max-width: 100%;
+  cursor: pointer;
+}
+
+.sampleSelect:focus {
+  outline: none;
+  border-color: var(--primary-500);
+  box-shadow: 0 0 0 3px rgb(14 165 233 / 0.1);
+}
+
 .textarea {
   width: 100%;
   flex: 1;

--- a/frontend/src/pages/PatternPage.tsx
+++ b/frontend/src/pages/PatternPage.tsx
@@ -6,7 +6,16 @@ import { PhysicsPatternView } from '../components/PhysicsPatternView';
 import { PhysicsNode } from '../pages/TestPageStuff/TestClasses';
 import { createParsedGraph } from '../utilities/parser';
 import { toggleCommentAtSelection } from '../utilities/patternTextComments';
+import { SAMPLE_PATTERNS } from '../data/samplePatterns';
 import styles from './PatternPage.module.css';
+
+function normalizeSampleTextForEditor(text: string): string {
+    return text
+        .replace(/\t+/g, '')
+        .split('\n')
+        .map((line) => line.trimStart())
+        .join('\n');
+}
 
 const PatternPage: React.FC = () => {
     const [text, setText] = useState<string>('');
@@ -32,6 +41,20 @@ const PatternPage: React.FC = () => {
         }
     }, [text]);
 
+    const handleSamplePatternChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+        const id = e.target.value;
+        if (!id) {
+            return;
+        }
+        const sample = SAMPLE_PATTERNS.find((p) => p.id === id);
+        if (!sample) {
+            return;
+        }
+        setText(normalizeSampleTextForEditor(sample.text));
+        // Reset to placeholder so the same sample can be loaded again.
+        e.currentTarget.value = '';
+    };
+
     return (
         <Layout>
             <div className={styles.container}>
@@ -56,9 +79,29 @@ const PatternPage: React.FC = () => {
                     {/* Center Panel - Pattern Text Input */}
                     <div className={styles.centerPanel}>
                         <div className={styles.patternInput}>
-                            <label htmlFor="pattern-text" className={styles.inputLabel}>
-                                Pattern Text
-                            </label>
+                            <div className={styles.patternInputHeader}>
+                                <label htmlFor="pattern-text" className={styles.inputLabel}>
+                                    Pattern Text
+                                </label>
+                                <div className={styles.samplePatternTools}>
+                                    <label htmlFor="sample-pattern-select" className="sr-only">
+                                        Load a sample pattern into the editor
+                                    </label>
+                                    <select
+                                        id="sample-pattern-select"
+                                        className={styles.sampleSelect}
+                                        onChange={handleSamplePatternChange}
+                                        aria-label="Sample patterns"
+                                    >
+                                        <option value="">Sample patterns…</option>
+                                        {SAMPLE_PATTERNS.map((sample) => (
+                                            <option key={sample.id} value={sample.id}>
+                                                {sample.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
                             <textarea
                                 id="pattern-text"
                                 className={styles.textarea}

--- a/frontend/src/pages/PatternPage.tsx
+++ b/frontend/src/pages/PatternPage.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
+import { flushSync } from 'react-dom';
 import Layout from './Layout';
 import { CreatePatternForm } from '../components/CreatePatternForm';
 import { PhysicsPatternView } from '../components/PhysicsPatternView';
 import { PhysicsNode } from '../pages/TestPageStuff/TestClasses';
 import { createParsedGraph } from '../utilities/parser';
+import { toggleCommentAtSelection } from '../utilities/patternTextComments';
 import styles from './PatternPage.module.css';
 
 const PatternPage: React.FC = () => {
@@ -64,6 +66,23 @@ const PatternPage: React.FC = () => {
                                 rows={8}
                                 value={text}
                                 onChange={(e) => setText(e.target.value)}
+                                onKeyDown={(e) => {
+                                    if (e.key !== '/' || (!e.metaKey && !e.ctrlKey)) {
+                                        return;
+                                    }
+                                    e.preventDefault();
+                                    const ta = e.currentTarget;
+                                    const { value, selectionStart, selectionEnd } = ta;
+                                    const next = toggleCommentAtSelection(
+                                        value,
+                                        selectionStart,
+                                        selectionEnd
+                                    );
+                                    flushSync(() => {
+                                        setText(next.text);
+                                    });
+                                    ta.setSelectionRange(next.selectionStart, next.selectionEnd);
+                                }}
                             />
                         </div>
                     </div>

--- a/frontend/src/pages/TestPageStuff/useSpringSimulation.ts
+++ b/frontend/src/pages/TestPageStuff/useSpringSimulation.ts
@@ -6,99 +6,105 @@ interface SimulationParams {
     nodes: PhysicsNode[];
     kSpring?: number;
     kCoulomb?: number;
+    /** Velocity retention per step (lower = heavier damping, settles faster but can feel sluggish if too low). */
     damping?: number;
     dt?: number;
     minDist?: number;
+    /** Physics steps per frame — more steps advance the simulation faster with less instability than one huge dt. */
+    substeps?: number;
 }
 
 export function useSpringSimulation({
     nodes,
-    kSpring = 1,
-    kCoulomb = 5,
-    damping = 0.5,
-    dt = 0.02,
+    kSpring = 2.4,
+    kCoulomb = 6,
+    damping = 0.48,
+    dt = 0.05,
     minDist = 0.3,
+    substeps = 3,
 }: SimulationParams) {
     useFrame(() => {
-        // reset forces
-        for (const n of nodes) {
-            n.ax = n.ay = n.az = 0;
-        }
-
-        // springs
-        const nodeIndexMap = new Map<PhysicsNode, number>();
-        nodes.forEach((node, index) => nodeIndexMap.set(node, index));
-        const processed = new Set<string>();
-        for (const n1 of nodes) {
-            for (const n2 of n1.neighbors) {
-                // Avoid processing the same edge twice (A->B and B->A)
-                const idx1 = nodeIndexMap.get(n1)!;
-                const idx2 = nodeIndexMap.get(n2)!;
-                const key1 = `${idx1}-${idx2}`;
-                const key2 = `${idx2}-${idx1}`;
-                if (processed.has(key1) || processed.has(key2)) continue;
-                processed.add(key1);
-
-                const dx = n2.x - n1.x;
-                const dy = n2.y - n1.y;
-                const dz = n2.z - n1.z;
-
-                const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 0.001;
-                const restLength = n1.restLength;
-                const force = kSpring * (dist - restLength);
-                const inv = 1 / dist;
-
-                const fx = dx * inv * force;
-                const fy = dy * inv * force;
-                const fz = dz * inv * force;
-
-                n1.ax += fx;
-                n1.ay += fy;
-                n1.az += fz;
-                n2.ax -= fx;
-                n2.ay -= fy;
-                n2.az -= fz;
+        for (let step = 0; step < substeps; step++) {
+            // reset forces
+            for (const n of nodes) {
+                n.ax = n.ay = n.az = 0;
             }
-        }
 
-        // repulsion
-        for (let i = 0; i < nodes.length; i++) {
-            for (let j = i + 1; j < nodes.length; j++) {
-                const a = nodes[i];
-                const b = nodes[j];
+            // springs
+            const nodeIndexMap = new Map<PhysicsNode, number>();
+            nodes.forEach((node, index) => nodeIndexMap.set(node, index));
+            const processed = new Set<string>();
+            for (const n1 of nodes) {
+                for (const n2 of n1.neighbors) {
+                    // Avoid processing the same edge twice (A->B and B->A)
+                    const idx1 = nodeIndexMap.get(n1)!;
+                    const idx2 = nodeIndexMap.get(n2)!;
+                    const key1 = `${idx1}-${idx2}`;
+                    const key2 = `${idx2}-${idx1}`;
+                    if (processed.has(key1) || processed.has(key2)) continue;
+                    processed.add(key1);
 
-                const dx = b.x - a.x;
-                const dy = b.y - a.y;
-                const dz = b.z - a.z;
+                    const dx = n2.x - n1.x;
+                    const dy = n2.y - n1.y;
+                    const dz = n2.z - n1.z;
 
-                const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 0.001;
-                const d = Math.max(dist, minDist);
+                    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 0.001;
+                    const restLength = n1.restLength;
+                    const force = kSpring * (dist - restLength);
+                    const inv = 1 / dist;
 
-                const force = kCoulomb / (d * d);
-                const inv = 1 / dist;
+                    const fx = dx * inv * force;
+                    const fy = dy * inv * force;
+                    const fz = dz * inv * force;
 
-                const fx = -dx * inv * force;
-                const fy = -dy * inv * force;
-                const fz = -dz * inv * force;
-
-                a.ax += fx;
-                a.ay += fy;
-                a.az += fz;
-                b.ax -= fx;
-                b.ay -= fy;
-                b.az -= fz;
+                    n1.ax += fx;
+                    n1.ay += fy;
+                    n1.az += fz;
+                    n2.ax -= fx;
+                    n2.ay -= fy;
+                    n2.az -= fz;
+                }
             }
-        }
 
-        // integrate
-        for (const n of nodes) {
-            n.vx = (n.vx + n.ax * dt) * damping;
-            n.vy = (n.vy + n.ay * dt) * damping;
-            n.vz = (n.vz + n.az * dt) * damping;
+            // repulsion
+            for (let i = 0; i < nodes.length; i++) {
+                for (let j = i + 1; j < nodes.length; j++) {
+                    const a = nodes[i];
+                    const b = nodes[j];
 
-            n.x += n.vx;
-            n.y += n.vy;
-            n.z += n.vz;
+                    const dx = b.x - a.x;
+                    const dy = b.y - a.y;
+                    const dz = b.z - a.z;
+
+                    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 0.001;
+                    const d = Math.max(dist, minDist);
+
+                    const force = kCoulomb / (d * d);
+                    const inv = 1 / dist;
+
+                    const fx = -dx * inv * force;
+                    const fy = -dy * inv * force;
+                    const fz = -dz * inv * force;
+
+                    a.ax += fx;
+                    a.ay += fy;
+                    a.az += fz;
+                    b.ax -= fx;
+                    b.ay -= fy;
+                    b.az -= fz;
+                }
+            }
+
+            // integrate
+            for (const n of nodes) {
+                n.vx = (n.vx + n.ax * dt) * damping;
+                n.vy = (n.vy + n.ay * dt) * damping;
+                n.vz = (n.vz + n.az * dt) * damping;
+
+                n.x += n.vx;
+                n.y += n.vy;
+                n.z += n.vz;
+            }
         }
     });
 }

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -5,6 +5,89 @@ function connectNodes(n1: PhysicsNode, n2: PhysicsNode) {
     if (!n2.neighbors.includes(n1)) n2.neighbors.push(n1);
 }
 
+/** Physical parent indices 0..P-1 for each stitch: start at last (P-1), walk backward, bounce at ends repeating the corner stitch then reversing direction. */
+function lineParentSequence(P: number, n: number): number[] {
+    if (P < 1 || n < 1) {
+        return [];
+    }
+    if (P === 1) {
+        return Array.from({ length: n }, () => 0);
+    }
+    const seq: number[] = [];
+    let pos = P - 1;
+    let dir = -1;
+    for (let i = 0; i < n; i++) {
+        seq.push(pos);
+        if (i === n - 1) {
+            break;
+        }
+        const nextPos = pos + dir;
+        if (nextPos < 0) {
+            pos = 0;
+            dir = 1;
+            continue;
+        }
+        if (nextPos >= P) {
+            pos = P - 1;
+            dir = -1;
+            continue;
+        }
+        pos = nextPos;
+    }
+    return seq;
+}
+
+/**
+ * Line → loop closing round: skip parent 0; go along C1..C_{P-1}, then back C_{P-1}..C1 (N = 2(P-1)).
+ */
+function chainToLoopParentSequence(P: number): number[] {
+    const seq: number[] = [];
+    for (let i = 1; i <= P - 1; i++) {
+        seq.push(i);
+    }
+    for (let i = P - 1; i >= 1; i--) {
+        seq.push(i);
+    }
+    return seq;
+}
+
+/** Line-to-loop skips parent C0; every other chain parent 1..P-1 must appear at least once. */
+function assertChainToLoopConsumesAllParentsExceptSkipped(
+    parentLocal: number[],
+    P: number,
+    rowCounter: number
+): void {
+    for (const idx of parentLocal) {
+        if (idx < 1 || idx >= P) {
+            throw new Error(
+                `Row ${rowCounter}: line-to-loop row must only attach to parents 1..${P - 1} (C0 skipped), got ${idx}`
+            );
+        }
+    }
+    const used = new Set(parentLocal);
+    for (let p = 1; p <= P - 1; p++) {
+        if (!used.has(p)) {
+            throw new Error(
+                `Row ${rowCounter}: line-to-loop row must use every parent stitch from C1 to C${P - 1} (C0 skipped); missing parent index ${p}`
+            );
+        }
+    }
+}
+
+/** True when the row has more than one stitch and its first and last nodes are neighbors (closed ring). */
+export function rowFirstAndLastAreNeighbors(
+    nodes: PhysicsNode[],
+    rowStart: number,
+    stitchCount: number
+): boolean {
+    if (stitchCount <= 1) {
+        return false;
+    }
+    const first = nodes[rowStart];
+    const last = nodes[rowStart + stitchCount - 1];
+    return first.neighbors.includes(last);
+}
+
 function tokenizeStitches(input: string, separator = ","): string[] {
     return input
         .split(separator)
@@ -15,7 +98,9 @@ function tokenizeStitches(input: string, separator = ","): string[] {
 
 type ParsedLine =
   | { type: "color"; value: string }
-  | { type: "row"; stitches: string[] };
+  | { type: "row"; stitches: string[] }
+  | { type: "startMagicRing"; count: number }
+  | { type: "startChain"; count: number };
 
 function expandRowLine(line: string): string[] {
     const tokens = line.toLowerCase().match(/\(|\)|,|[a-zA-Z]+x\d+|x|\d+|[a-zA-Z]+/g);
@@ -131,6 +216,26 @@ function parsePatternLines(pattern: string): ParsedLine[] {
             continue;
         }
 
+        const mr = line.match(/^\s*mr\s*(\d+)\s*$/i);
+        if (mr) {
+            const count = parseInt(mr[1], 10);
+            if (count < 1) {
+                throw new Error("Magic ring stitch count must be at least 1");
+            }
+            result.push({ type: "startMagicRing", count });
+            continue;
+        }
+
+        const ch = line.match(/^\s*ch\s*(\d+)\s*$/i);
+        if (ch) {
+            const count = parseInt(ch[1], 10);
+            if (count < 1) {
+                throw new Error("Chain stitch count must be at least 1");
+            }
+            result.push({ type: "startChain", count });
+            continue;
+        }
+
         const stitches = expandRowLine(line);
         if (stitches.length > 0) {
             result.push({ type: "row", stitches });
@@ -139,7 +244,7 @@ function parsePatternLines(pattern: string): ParsedLine[] {
     return result;
 }
 
-export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => {
+export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; lastRowIsLoop: boolean } => {
     const nodes: PhysicsNode[] = [];
 
     const parsedLines = parsePatternLines(pattern);
@@ -149,6 +254,10 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
     let prevRowCount = 0;
     let nodesBeforePrevRow = 0;
     let rowCounter = 0;
+    /** True when the previous row is worked in the round (not a flat chain row). */
+    let prevRowWasLoopRound: boolean = false;
+    /** Index of first chain stitch (C0) after `ch`; cleared after the first stitch row on that chain. */
+    let chainFoundationFirstNode: number | null = null;
 
     for (const entry of parsedLines) {
         if (entry.type === "color") {
@@ -156,18 +265,79 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
             continue;
         }
 
+        if (entry.type === "startMagicRing" || entry.type === "startChain") {
+            if (nodes.length !== 0) {
+                throw new Error(
+                    `${entry.type === "startMagicRing" ? "mr" : "ch"} must be the first stitch row (only color lines may precede it)`
+                );
+            }
+        }
+
         rowCounter++;
+
+        if (entry.type === "startMagicRing") {
+            const currentRowCountStart = nodes.length;
+            for (let i = 0; i < entry.count; i++) {
+                nodes.push(new PhysicsNode(currentColor));
+            }
+            const currentRowCount = nodes.length - currentRowCountStart;
+            if (currentRowCount > 1) {
+                for (let i = 1; i < currentRowCount; i++) {
+                    connectNodes(nodes[currentRowCountStart + i - 1], nodes[currentRowCountStart + i]);
+                }
+                connectNodes(nodes[currentRowCountStart], nodes[nodes.length - 1]);
+            }
+            nodesBeforePrevRow = currentRowCountStart;
+            prevRowCount = currentRowCount;
+            prevRowWasLoopRound = true;
+            continue;
+        }
+
+        if (entry.type === "startChain") {
+            const currentRowCountStart = nodes.length;
+            for (let i = 0; i < entry.count; i++) {
+                nodes.push(new PhysicsNode(currentColor));
+            }
+            const currentRowCount = nodes.length - currentRowCountStart;
+            if (currentRowCount > 1) {
+                for (let i = 1; i < currentRowCount; i++) {
+                    connectNodes(nodes[currentRowCountStart + i - 1], nodes[currentRowCountStart + i]);
+                }
+            }
+            nodesBeforePrevRow = currentRowCountStart;
+            prevRowCount = currentRowCount;
+            prevRowWasLoopRound = false;
+            chainFoundationFirstNode = currentRowCountStart;
+            continue;
+        }
 
         const row = entry.stitches;
         const currentRowCountStart = nodes.length;
         let prevIndex = 0;
+        let attachChainTipToFirstStitch = false;
 
         if (nodes.length === 0) {
-            for (let i = 0; i < row.length; i++) {
-                nodes.push(new PhysicsNode(currentColor));
-            }
-        } else {
-            for (const stitch of row) {
+            throw new Error(
+                `Row ${rowCounter}: start with mr<number> or ch<number> (e.g. mr6 or ch6); optional color lines may come first`
+            );
+        }
+
+        {
+            const parentWasLoopRound: boolean = prevRowWasLoopRound;
+            const P = prevRowCount;
+            const n = row.length;
+
+            /** Only all-sc rows can close a chain into a loop (avoid (sc,inc)x2 matching n = 2(P-1) by accident). */
+            const isChainToLoopRound: boolean =
+                !parentWasLoopRound &&
+                P >= 2 &&
+                n === 2 * (P - 1) &&
+                row.every((s: string) => s === "sc");
+
+            const lastNodeOfPrevRow = nodes[nodesBeforePrevRow + prevRowCount - 1];
+
+            const processStitchAlongParentsLoop = (stitch: string) => {
+                const firstStitchInRow = prevIndex === 0;
                 switch (stitch) {
                     case "sc": {
                         if (prevIndex >= prevRowCount) {
@@ -178,6 +348,9 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
 
                         nodes.push(new PhysicsNode(currentColor));
                         connectNodes(nodes[nodeIndex], nodes[parentIndex]);
+                        if (firstStitchInRow) {
+                            connectNodes(nodes[nodeIndex], lastNodeOfPrevRow);
+                        }
 
                         prevIndex += 1;
                         break;
@@ -196,6 +369,9 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
 
                         connectNodes(nodes[nodeIndex1], nodes[parentIndex]);
                         connectNodes(nodes[nodeIndex2], nodes[parentIndex]);
+                        if (firstStitchInRow) {
+                            connectNodes(nodes[nodeIndex1], lastNodeOfPrevRow);
+                        }
 
                         prevIndex += 1;
                         break;
@@ -213,6 +389,9 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
 
                         connectNodes(nodes[nodeIndex], nodes[parentIndex1]);
                         connectNodes(nodes[nodeIndex], nodes[parentIndex2]);
+                        if (firstStitchInRow) {
+                            connectNodes(nodes[nodeIndex], lastNodeOfPrevRow);
+                        }
 
                         prevIndex += 2;
                         break;
@@ -221,32 +400,119 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
                     default:
                         throw new Error(`Unknown stitch type: ${stitch}`);
                 }
+            };
+
+            if (parentWasLoopRound) {
+                for (const stitch of row) {
+                    processStitchAlongParentsLoop(stitch);
+                }
+            } else {
+                if (isChainToLoopRound) {
+                    const parentLocal = chainToLoopParentSequence(P);
+                    if (parentLocal.length !== n) {
+                        throw new Error(
+                            `Row ${rowCounter}: line-to-loop row must have exactly ${parentLocal.length} stitches (2(P-1)), got ${n}`
+                        );
+                    }
+                    for (let si = 0; si < n; si++) {
+                        const nodeIndex = nodes.length;
+                        const parentIndex = nodesBeforePrevRow + parentLocal[si];
+                        nodes.push(new PhysicsNode(currentColor));
+                        connectNodes(nodes[nodeIndex], nodes[parentIndex]);
+                        if (si === 0) {
+                            connectNodes(nodes[nodeIndex], nodes[nodesBeforePrevRow]);
+                        }
+                    }
+                    assertChainToLoopConsumesAllParentsExceptSkipped(parentLocal, P, rowCounter);
+                } else {
+                    const parentSeq = lineParentSequence(P, n);
+                    if (parentSeq.length !== n) {
+                        throw new Error(`Row ${rowCounter}: invalid line parent sequence`);
+                    }
+                    const processStitchAlongParentsLine = (stitch: string) => {
+                        const firstStitchInRow = prevIndex === 0;
+                        const physicalParent = parentSeq[prevIndex];
+                        switch (stitch) {
+                            case "sc": {
+                                const nodeIndex = nodes.length;
+                                const parentIndex = nodesBeforePrevRow + physicalParent;
+                                nodes.push(new PhysicsNode(currentColor));
+                                connectNodes(nodes[nodeIndex], nodes[parentIndex]);
+                                if (firstStitchInRow) {
+                                    connectNodes(nodes[nodeIndex], lastNodeOfPrevRow);
+                                }
+                                prevIndex += 1;
+                                break;
+                            }
+                            case "inc": {
+                                const parentIndex = nodesBeforePrevRow + physicalParent;
+                                const nodeIndex1 = nodes.length;
+                                const nodeIndex2 = nodes.length + 1;
+                                nodes.push(new PhysicsNode(currentColor), new PhysicsNode(currentColor));
+                                connectNodes(nodes[nodeIndex1], nodes[parentIndex]);
+                                connectNodes(nodes[nodeIndex2], nodes[parentIndex]);
+                                if (firstStitchInRow) {
+                                    connectNodes(nodes[nodeIndex1], lastNodeOfPrevRow);
+                                }
+                                prevIndex += 1;
+                                break;
+                            }
+                            case "dec":
+                                throw new Error(
+                                    `Row ${rowCounter}: dec is not supported after a chain row (flat row uses a backward walk)`
+                                );
+                            default:
+                                throw new Error(`Unknown stitch type: ${stitch}`);
+                        }
+                    };
+                    for (const stitch of row) {
+                        processStitchAlongParentsLine(stitch);
+                    }
+                }
             }
 
-            // must consume all parent stitches
-            if (prevIndex !== prevRowCount) {
-                throw new Error(
-                    `Row ${rowCounter}: Expected to consume ${prevRowCount} parent stitches, but consumed ${prevIndex}`
-                );
+            prevRowWasLoopRound = parentWasLoopRound || isChainToLoopRound;
+
+            attachChainTipToFirstStitch =
+                chainFoundationFirstNode !== null &&
+                !parentWasLoopRound &&
+                !isChainToLoopRound;
+
+            if (parentWasLoopRound) {
+                if (prevIndex !== prevRowCount) {
+                    throw new Error(
+                        `Row ${rowCounter}: Expected to consume ${prevRowCount} parent stitches, but consumed ${prevIndex}`
+                    );
+                }
+            } else if (!isChainToLoopRound) {
+                if (prevIndex !== n) {
+                    throw new Error(
+                        `Row ${rowCounter}: Expected ${n} stitches in this row, but processed ${prevIndex}`
+                    );
+                }
             }
         }
 
         const currentRowCount = nodes.length - currentRowCountStart;
-        
-        if (currentRowCount > 1) {
-            // connect the first and last stitch of a row
-            connectNodes(nodes[currentRowCountStart], nodes[nodes.length - 1]);
 
-            // connect neighbors in same row
+        if (currentRowCount > 1) {
             for (let i = 1; i < currentRowCount; i++) {
                 connectNodes(nodes[currentRowCountStart + i - 1], nodes[currentRowCountStart + i]);
             }
         }
 
-        // update row trackers
+        if (chainFoundationFirstNode !== null) {
+            if (attachChainTipToFirstStitch && currentRowCount > 0) {
+                connectNodes(nodes[chainFoundationFirstNode], nodes[currentRowCountStart]);
+            }
+            chainFoundationFirstNode = null;
+        }
+
         nodesBeforePrevRow = currentRowCountStart;
         prevRowCount = currentRowCount;
     }
 
-    return { nodes };
+    const lastRowIsLoop = prevRowCount > 0 && prevRowWasLoopRound;
+
+    return { nodes, lastRowIsLoop };
 }

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -5,13 +5,20 @@ function connectNodes(n1: PhysicsNode, n2: PhysicsNode) {
     if (!n2.neighbors.includes(n1)) n2.neighbors.push(n1);
 }
 
+function tokenizeStitches(input: string, separator = ","): string[] {
+    return input
+        .split(separator)
+        .map((s) => s.trim())
+        .map((s) => s.toLowerCase())
+        .filter(Boolean);
+}
+
 type ParsedLine =
   | { type: "color"; value: string }
   | { type: "row"; stitches: string[] };
 
 function parsePatternLines(pattern: string): ParsedLine[] {
-    // 1. Filter out empty lines from the initial split
-    const lines = pattern.split('\n').map(l => l.trim()).filter(Boolean);
+    const lines = tokenizeStitches(pattern, "\n");
     const result: ParsedLine[] = [];
 
     for (const line of lines) {
@@ -27,8 +34,7 @@ function parsePatternLines(pattern: string): ParsedLine[] {
         if (match) {
             const group = match[1];
             const count = parseInt(match[2], 10);
-
-            const stitches = group.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+            const stitches = tokenizeStitches(group);
 
             const expanded: string[] = [];
             for (let i = 0; i < count; i++) {
@@ -37,7 +43,7 @@ function parsePatternLines(pattern: string): ParsedLine[] {
             result.push({ type: "row", stitches: expanded });
         } else {
             // already expanded row
-            const stitches = line.split(',').map(s => s.trim().toLowerCase()).filter(Boolean);
+            const stitches = tokenizeStitches(line);
             if (stitches.length > 0) {
                 result.push({ type: "row", stitches });
             }
@@ -69,14 +75,11 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
         const currentRowCountStart = nodes.length;
         let prevIndex = 0;
 
-        // first row: just create nodes
         if (nodes.length === 0) {
             for (let i = 0; i < row.length; i++) {
                 nodes.push(new PhysicsNode(currentColor));
             }
-        } 
-        // all other rows
-        else {
+        } else {
             for (const stitch of row) {
                 switch (stitch) {
                     case "sc": {
@@ -102,7 +105,7 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[] } => 
                         const nodeIndex1 = nodes.length;
                         const nodeIndex2 = nodes.length + 1;
 
-                        nodes.push(new PhysicsNode(currentColor),new PhysicsNode(currentColor));
+                        nodes.push(new PhysicsNode(currentColor), new PhysicsNode(currentColor));
 
                         connectNodes(nodes[nodeIndex1], nodes[parentIndex]);
                         connectNodes(nodes[nodeIndex2], nodes[parentIndex]);

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -451,6 +451,10 @@ function parsePatternLines(pattern: string): ParsedLine[] {
     const result: ParsedLine[] = [];
 
     for (const line of lines) {
+        if (line.trimStart().startsWith("//")) {
+            continue;
+        }
+
         // color line (word or hex)
         if (/^([a-zA-Z]+|#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}))$/.test(line)) {
             result.push({ type: "color", value: line });

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -34,7 +34,7 @@ type LoopRowContext = RowContextBase & {
 
 type FlatLineRowContext = RowContextBase;
 
-type ChainToLoopRowContext = {
+type AlongChainRowContext = {
     nodes: PhysicsNode[];
     nodesBeforePrevRow: number;
     parentRowCount: number;
@@ -309,56 +309,59 @@ function flatLineParentSequence(P: number, n: number): number[] {
 }
 
 /**
- * Line → loop closing round: skip parent 0; go along C1..C_{P-1}, then back C_{P-1}..C1 (N = 2(P-1)).
+ * Flat rectangle along a starting chain: skip C0 on the first pass (C1..C_{P-1}), turn at C_{P-1},
+ * then work back skipping that corner (C_{P-2}..C0). N = 2(P−1) stitches.
  */
-function chainToLoopParentSequence(P: number): number[] {
+function rectangleFlatAlongChainParentSequence(P: number): number[] {
     const seq: number[] = [];
     for (let i = 1; i <= P - 1; i++) {
         seq.push(i);
     }
-    for (let i = P - 1; i >= 1; i--) {
+    for (let i = P - 2; i >= 0; i--) {
         seq.push(i);
     }
     return seq;
 }
 
-/** Line-to-loop skips parent C0; every other chain parent 1..P-1 must appear at least once. */
-function assertChainToLoopConsumesAllParentsExceptSkipped(
-    parentLocal: number[],
-    P: number,
-    rowCounter: number
-): void {
-    for (const idx of parentLocal) {
-        if (idx < 1 || idx >= P) {
-            throw rowErr(
-                rowCounter,
-                `line-to-loop row must only attach to parents 1..${P - 1} (C0 skipped), got ${idx}`
-            );
-        }
+/**
+ * Rows that walk the chain with turns repeat a corner index twice (same foundation stitch on
+ * opposite passes). If the first of two identical parents was an increase, the next stitch must
+ * attach to the neighbor inward — not again into the corner (right turn: P−1 → P−2; left turn at 0 → 1).
+ */
+function adjustParentsAfterCornerIncrease(parentLocal: number[], row: string[], P: number): void {
+    if (P < 2) {
+        return;
     }
-    const used = new Set(parentLocal);
-    for (let p = 1; p <= P - 1; p++) {
-        if (!used.has(p)) {
-            throw rowErr(
-                rowCounter,
-                `line-to-loop row must use every parent stitch from C1 to C${P - 1} (C0 skipped); missing parent index ${p}`
-            );
+    for (let i = 1; i < parentLocal.length; i++) {
+        if (parentLocal[i] !== parentLocal[i - 1]) {
+            continue;
+        }
+        if (parseIncChildCount(row[i - 1]) === null) {
+            continue;
+        }
+        const p = parentLocal[i];
+        if (p === P - 1) {
+            parentLocal[i] = P - 2;
+        } else if (p === 0) {
+            parentLocal[i] = 1;
         }
     }
 }
 
-function applyChainToLoopRow(
+function applyRectangleFlatAlongChainRow(
     row: string[],
-    ctx: ChainToLoopRowContext
+    ctx: AlongChainRowContext
 ): void {
     const n = row.length;
-    const parentLocal = chainToLoopParentSequence(ctx.parentRowCount);
-    if (parentLocal.length !== n) {
+    const baseSequence = rectangleFlatAlongChainParentSequence(ctx.parentRowCount);
+    if (baseSequence.length !== n) {
         throw rowErr(
             ctx.rowCounter,
-            `line-to-loop row must have exactly ${parentLocal.length} stitches (2(P-1)), got ${n}`
+            `flat along-chain row must have exactly ${baseSequence.length} stitches (2(P-1)), got ${n}`
         );
     }
+    const parentLocal = baseSequence.slice();
+    adjustParentsAfterCornerIncrease(parentLocal, row, ctx.parentRowCount);
     const { nodes, nodesBeforePrevRow, rowCounter, currentColor } = ctx;
     const chainTipC0 = nodes[nodesBeforePrevRow];
 
@@ -368,24 +371,9 @@ function applyChainToLoopRow(
 
         const consumedParents = applyScOrIncStitch(row[si], nodes, parentIndex, stitchOpts);
         if (consumedParents === null) {
-            throw rowErr(rowCounter, "dec is not supported in a line-to-loop closing round");
+            throw rowErr(rowCounter, "dec is not supported in a flat along-chain row");
         }
     }
-    assertChainToLoopConsumesAllParentsExceptSkipped(parentLocal, ctx.parentRowCount, rowCounter);
-}
-
-/** True when the row has more than one stitch and its first and last nodes are neighbors (closed ring). */
-export function rowFirstAndLastAreNeighbors(
-    nodes: PhysicsNode[],
-    rowStart: number,
-    stitchCount: number
-): boolean {
-    if (stitchCount <= 1) {
-        return false;
-    }
-    const first = nodes[rowStart];
-    const last = nodes[rowStart + stitchCount - 1];
-    return first.neighbors.includes(last);
 }
 
 function tokenizeStitches(input: string, separator = ","): string[] {
@@ -396,8 +384,9 @@ function tokenizeStitches(input: string, separator = ","): string[] {
         .filter(Boolean);
 }
 
+/** Expects a line already lowercased (see `tokenizeStitches`). */
 function expandRowLine(line: string): string[] {
-    const tokens = line.toLowerCase().match(ROW_TOKEN_RE);
+    const tokens = line.match(ROW_TOKEN_RE);
     if (!tokens || tokens.length === 0) {
         return [];
     }
@@ -548,8 +537,8 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
     const nodes: PhysicsNode[] = [];
 
     const parsedLines = parsePatternLines(pattern);
-    
-    let currentColor: string | undefined = undefined;
+
+    let currentColor: string | undefined;
 
     let prevRowCount = 0;
     let nodesBeforePrevRow = 0;
@@ -558,8 +547,16 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
     let prevRowWasLoopRound: boolean = false;
     /** Index of first chain stitch (C0) after `ch`; cleared after the first stitch row on that chain. */
     let chainFoundationFirstNode: number | null = null;
+    /** After `ch` + flat along-chain row (2(P−1) first row), the next loop round should close (first ↔ last stitch). */
+    let ringCloseFirstLoopAfterChain: boolean = false;
 
-    for (const entry of parsedLines) {
+    const indexOfLastStitchRow = parsedLines.reduce(
+        (last, line, i) => (line.type === "row" ? i : last),
+        -1
+    );
+
+    for (let parsedLineIndex = 0; parsedLineIndex < parsedLines.length; parsedLineIndex++) {
+        const entry = parsedLines[parsedLineIndex];
         if (entry.type === "color") {
             currentColor = entry.value;
             continue;
@@ -610,6 +607,8 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
         const row = entry.stitches;
         const currentRowCountStart = nodes.length;
         let prevIndex = 0;
+        /** Incoming: previous row was worked in the round → this row uses `processLoopRoundRow`. */
+        const rowParentIsLoopRound = prevRowWasLoopRound;
 
         if (nodes.length === 0) {
             throw rowErr(
@@ -627,20 +626,22 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
             const isFirstRowAfterChain: boolean =
                 chainFoundationFirstNode !== null && !parentWasLoopRound;
 
+            const twoPassAlongChainStitchCount = 2 * (parentRowCount - 1);
+
             if (isFirstRowAfterChain) {
                 const isFlatFirstRowValid = flatRowParentConsumption === parentRowCount;
-                const isChainToLoopRowValid = rowStitchCount === 2 * (parentRowCount - 1);
-                if (!isFlatFirstRowValid && !isChainToLoopRowValid) {
+                const isTwoPassAlongChainValid = rowStitchCount === twoPassAlongChainStitchCount;
+                if (!isFlatFirstRowValid && !isTwoPassAlongChainValid) {
                     throw rowErr(
                         rowCounter,
-                        `First row after a starting chain must consume exactly P (${parentRowCount}) parent stitches (flat line) or have exactly 2(P-1) (${2 * (parentRowCount - 1)}) stitches (line to loop); got ${rowStitchCount} stitches consuming ${flatRowParentConsumption} parents`
+                        `First row after a starting chain must consume exactly P (${parentRowCount}) parent stitches (one pass) or have exactly 2(P-1) (${twoPassAlongChainStitchCount}) stitches (flat out-and-back along the chain); got ${rowStitchCount} stitches consuming ${flatRowParentConsumption} parents`
                     );
                 }
             }
 
-            /** First working row after `ch` with N = 2(P−1) closes the chain into a loop. */
-            const isChainToLoopRound: boolean =
-                isFirstRowAfterChain && rowStitchCount === 2 * (parentRowCount - 1);
+            /** First working row after `ch` with 2(P−1) stitches: flat along chain (skip C0 out, skip turn stitch back). */
+            const isRectangleFlatAlongChainRow: boolean =
+                isFirstRowAfterChain && rowStitchCount === twoPassAlongChainStitchCount;
 
             const lastNodeOfPrevRow = nodes[nodesBeforePrevRow + prevRowCount - 1];
 
@@ -653,18 +654,22 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
                     currentColor,
                     lastNodeOfPrevRow,
                 });
-            } else if (isChainToLoopRound) {
-                applyChainToLoopRow(row, {
+            } else if (isRectangleFlatAlongChainRow) {
+                applyRectangleFlatAlongChainRow(row, {
                     nodes,
                     nodesBeforePrevRow,
                     parentRowCount,
                     rowCounter,
                     currentColor,
                 });
+                prevIndex = flatRowParentConsumption;
             } else {
                 const parentSeq = flatLineParentSequence(parentRowCount, flatRowParentConsumption);
                 if (parentSeq.length !== flatRowParentConsumption) {
                     throw rowErr(rowCounter, "invalid line parent sequence");
+                }
+                if (flatRowParentConsumption > parentRowCount) {
+                    adjustParentsAfterCornerIncrease(parentSeq, row, parentRowCount);
                 }
                 prevIndex = processFlatLineRow(row, parentSeq, {
                     nodes,
@@ -675,21 +680,28 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
                 });
             }
 
-            prevRowWasLoopRound = parentWasLoopRound || isChainToLoopRound;
+            prevRowWasLoopRound = parentWasLoopRound || isRectangleFlatAlongChainRow;
 
-            if (parentWasLoopRound) {
-                if (prevIndex !== prevRowCount) {
-                    throw rowErr(
-                        rowCounter,
-                        `Expected to consume ${prevRowCount} parent stitches, but consumed ${prevIndex}`
-                    );
-                }
-            } else if (!isChainToLoopRound) {
-                if (prevIndex !== flatRowParentConsumption) {
-                    throw rowErr(
-                        rowCounter,
-                        `Expected to consume ${flatRowParentConsumption} parent stitches in this row, but consumed ${prevIndex}`
-                    );
+            if (isRectangleFlatAlongChainRow) {
+                ringCloseFirstLoopAfterChain = true;
+            }
+
+            const isLastStitchRow = parsedLineIndex === indexOfLastStitchRow;
+            if (!isLastStitchRow) {
+                if (parentWasLoopRound) {
+                    if (prevIndex !== prevRowCount) {
+                        throw rowErr(
+                            rowCounter,
+                            `Expected to consume ${prevRowCount} parent stitches, but consumed ${prevIndex}`
+                        );
+                    }
+                } else if (!isRectangleFlatAlongChainRow) {
+                    if (prevIndex !== flatRowParentConsumption) {
+                        throw rowErr(
+                            rowCounter,
+                            `Expected to consume ${flatRowParentConsumption} parent stitches in this row, but consumed ${prevIndex}`
+                        );
+                    }
                 }
             }
         }
@@ -698,6 +710,10 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
 
         if (currentRowCount > 1) {
             connectAdjacentNodesInRow(nodes, currentRowCountStart, currentRowCount);
+            if (ringCloseFirstLoopAfterChain && rowParentIsLoopRound) {
+                connectNodes(nodes[currentRowCountStart], nodes[nodes.length - 1]);
+                ringCloseFirstLoopAfterChain = false;
+            }
         }
 
         // Do not connect chain tip C0 to the first sc on flat rows — that edge closes a loop around the foundation.

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -5,6 +5,14 @@ function connectNodes(n1: PhysicsNode, n2: PhysicsNode) {
     if (!n2.neighbors.includes(n1)) n2.neighbors.push(n1);
 }
 
+const INC_STITCH_RE = /^inc(\d+)$/;
+const ROW_TOKEN_RE = /\(|\)|,|[a-zA-Z]+x\d+|inc\d+|x|\d+|[a-zA-Z]+/g;
+const UNEXPECTED_NUMBER_RE = /^\d+$/;
+const SINGLE_STITCH_WITH_MULTIPLIER_RE = /^([a-zA-Z]+)x(\d+)$/;
+const COLOR_LINE_RE = /^([a-zA-Z]+|#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}))$/;
+const MAGIC_RING_RE = /^\s*mr\s*(\d+)\s*$/i;
+const CHAIN_RE = /^\s*ch\s*(\d+)\s*$/i;
+
 type StitchAttachmentOpts = {
     firstStitchInRow: boolean;
     /** End of the previous row in stitch order — models yarn running from there to the first stitch of this row. */
@@ -12,16 +20,62 @@ type StitchAttachmentOpts = {
     color?: string;
 };
 
+type RowContextBase = {
+    nodes: PhysicsNode[];
+    nodesBeforePrevRow: number;
+    rowCounter: number;
+    currentColor: string | undefined;
+    lastNodeOfPrevRow: PhysicsNode;
+};
+
+type LoopRowContext = RowContextBase & {
+    prevRowCount: number;
+};
+
+type FlatLineRowContext = RowContextBase;
+
+type ChainToLoopRowContext = {
+    nodes: PhysicsNode[];
+    nodesBeforePrevRow: number;
+    parentRowCount: number;
+    rowCounter: number;
+    currentColor: string | undefined;
+};
+
+type ParsedLine =
+    | { type: "color"; value: string }
+    | { type: "row"; stitches: string[] }
+    | { type: "startMagicRing"; count: number }
+    | { type: "startChain"; count: number };
+
+function makeStitchOpts(
+    firstStitchInRow: boolean,
+    lastNodeOfPrevRow: PhysicsNode,
+    color: string | undefined
+): StitchAttachmentOpts {
+    return { firstStitchInRow, lastNodeOfPrevRow, color };
+}
+
+function connectAdjacentNodesInRow(nodes: PhysicsNode[], rowStart: number, rowCount: number): void {
+    for (let i = 1; i < rowCount; i++) {
+        connectNodes(nodes[rowStart + i - 1], nodes[rowStart + i]);
+    }
+}
+
+function rowErr(rowCounter: number, detail: string): Error {
+    return new Error(`Row ${rowCounter}: ${detail}`);
+}
+
 function pushScStitch(
     nodes: PhysicsNode[],
     parentIndex: number,
     opts: StitchAttachmentOpts
 ): void {
-    const nodeIndex = nodes.length;
-    nodes.push(new PhysicsNode(opts.color));
-    connectNodes(nodes[nodeIndex], nodes[parentIndex]);
+    const newStitch = new PhysicsNode(opts.color);
+    nodes.push(newStitch);
+    connectNodes(newStitch, nodes[parentIndex]);
     if (opts.firstStitchInRow) {
-        connectNodes(nodes[nodeIndex], opts.lastNodeOfPrevRow);
+        connectNodes(newStitch, opts.lastNodeOfPrevRow);
     }
 }
 
@@ -55,7 +109,7 @@ function parseIncChildCount(stitch: string): number | null {
     if (stitch === "inc") {
         return 2;
     }
-    const m = stitch.match(/^inc(\d+)$/);
+    const m = stitch.match(INC_STITCH_RE);
     if (!m) {
         return null;
     }
@@ -72,6 +126,11 @@ function pushDecStitch(
     parentIndex2: number,
     opts: StitchAttachmentOpts
 ): void {
+    if (Math.abs(parentIndex2 - parentIndex1) !== 1) {
+        throw new Error(
+            `dec expects adjacent parent indices; got ${parentIndex1} and ${parentIndex2}`
+        );
+    }
     const nodeIndex = nodes.length;
     nodes.push(new PhysicsNode(opts.color));
     connectNodes(nodes[nodeIndex], nodes[parentIndex1]);
@@ -81,105 +140,126 @@ function pushDecStitch(
     }
 }
 
-type LoopRowContext = {
-    nodes: PhysicsNode[];
-    nodesBeforePrevRow: number;
-    prevRowCount: number;
-    rowCounter: number;
-    currentColor: string | undefined;
-    lastNodeOfPrevRow: PhysicsNode;
-};
+/**
+ * Applies sc/inc* stitches and returns how many parent stitches were consumed.
+ * Returns null for dec so callers can enforce mode-specific dec rules.
+ */
+function applyScOrIncStitch(
+    stitch: string,
+    nodes: PhysicsNode[],
+    parentIndex: number,
+    stitchOpts: StitchAttachmentOpts
+): number | null {
+    const incChildren = parseIncChildCount(stitch);
+    if (incChildren !== null) {
+        pushIncStitch(nodes, parentIndex, incChildren, stitchOpts);
+        return 1;
+    }
+    if (stitch === "sc") {
+        pushScStitch(nodes, parentIndex, stitchOpts);
+        return 1;
+    }
+    if (stitch === "dec") {
+        return null;
+    }
+    throw new Error(`Unknown stitch type: ${stitch}`);
+}
+
+/** Number of parent stitches consumed by one stitch token in flat/linear traversal. */
+function parentConsumptionForStitch(stitch: string): number {
+    if (stitch === "dec") {
+        return 2;
+    }
+    if (stitch === "sc" || parseIncChildCount(stitch) !== null) {
+        return 1;
+    }
+    throw new Error(`Unknown stitch type: ${stitch}`);
+}
+
+function parentConsumptionForRow(row: string[], rowCounter: number): number {
+    try {
+        return row.reduce((total, stitch) => total + parentConsumptionForStitch(stitch), 0);
+    } catch (error) {
+        if (error instanceof Error && error.message.startsWith("Unknown stitch type:")) {
+            throw rowErr(rowCounter, error.message);
+        }
+        throw error;
+    }
+}
 
 function processLoopRoundRow(row: string[], ctx: LoopRowContext): number {
-    let prevIndex = 0;
+    let parentCursor = 0;
     const { nodes, nodesBeforePrevRow, prevRowCount, rowCounter, currentColor, lastNodeOfPrevRow } = ctx;
 
     for (const stitch of row) {
-        const firstStitchInRow = prevIndex === 0;
-        const stitchOpts = { firstStitchInRow, lastNodeOfPrevRow, color: currentColor };
+        const stitchOpts = makeStitchOpts(parentCursor === 0, lastNodeOfPrevRow, currentColor);
 
-        const incChildren = parseIncChildCount(stitch);
-        if (incChildren !== null) {
-            if (prevIndex >= prevRowCount) {
-                throw new Error(`Row ${rowCounter}: Not enough parent stitches`);
-            }
-            pushIncStitch(nodes, nodesBeforePrevRow + prevIndex, incChildren, stitchOpts);
-            prevIndex += 1;
+        if (parentCursor >= prevRowCount) {
+            throw rowErr(rowCounter, "Not enough parent stitches");
+        }
+
+        const consumedParents = applyScOrIncStitch(
+            stitch,
+            nodes,
+            nodesBeforePrevRow + parentCursor,
+            stitchOpts
+        );
+        if (consumedParents !== null) {
+            parentCursor += consumedParents;
             continue;
         }
 
-        switch (stitch) {
-            case "sc": {
-                if (prevIndex >= prevRowCount) {
-                    throw new Error(`Row ${rowCounter}: Not enough parent stitches`);
-                }
-                pushScStitch(nodes, nodesBeforePrevRow + prevIndex, stitchOpts);
-                prevIndex += 1;
-                break;
-            }
-            case "dec": {
-                if (prevIndex + 1 >= prevRowCount) {
-                    throw new Error(`Row ${rowCounter}: dec requires 2 parent stitches`);
-                }
-                pushDecStitch(
-                    nodes,
-                    nodesBeforePrevRow + prevIndex,
-                    nodesBeforePrevRow + prevIndex + 1,
-                    stitchOpts
-                );
-                prevIndex += 2;
-                break;
-            }
-            default:
-                throw new Error(`Unknown stitch type: ${stitch}`);
+        if (parentCursor + 1 >= prevRowCount) {
+            throw rowErr(rowCounter, "dec requires 2 parent stitches");
         }
+        pushDecStitch(
+            nodes,
+            nodesBeforePrevRow + parentCursor,
+            nodesBeforePrevRow + parentCursor + 1,
+            stitchOpts
+        );
+        parentCursor += 2;
     }
-    return prevIndex;
+    return parentCursor;
 }
 
-type FlatLineRowContext = {
-    nodes: PhysicsNode[];
-    nodesBeforePrevRow: number;
-    rowCounter: number;
-    currentColor: string | undefined;
-    lastNodeOfPrevRow: PhysicsNode;
-};
-
 function processFlatLineRow(row: string[], parentSeq: number[], ctx: FlatLineRowContext): number {
-    let prevIndex = 0;
+    let parentCursor = 0;
     const { nodes, nodesBeforePrevRow, rowCounter, currentColor, lastNodeOfPrevRow } = ctx;
 
     for (const stitch of row) {
-        const firstStitchInRow = prevIndex === 0;
-        const physicalParent = parentSeq[prevIndex];
-        const stitchOpts: StitchAttachmentOpts = {
-            firstStitchInRow,
-            lastNodeOfPrevRow,
-            color: currentColor,
-        };
-        const parentIndex = nodesBeforePrevRow + physicalParent;
+        const stitchOpts = makeStitchOpts(parentCursor === 0, lastNodeOfPrevRow, currentColor);
+        const firstParent = parentSeq[parentCursor];
+        if (firstParent === undefined) {
+            throw rowErr(rowCounter, "Not enough parent stitches");
+        }
+        const parentIndex = nodesBeforePrevRow + firstParent;
 
-        const incChildren = parseIncChildCount(stitch);
-        if (incChildren !== null) {
-            pushIncStitch(nodes, parentIndex, incChildren, stitchOpts);
-            prevIndex += 1;
+        const consumedParents = applyScOrIncStitch(stitch, nodes, parentIndex, stitchOpts);
+        if (consumedParents !== null) {
+            parentCursor += consumedParents;
             continue;
         }
 
-        switch (stitch) {
-            case "sc":
-                pushScStitch(nodes, parentIndex, stitchOpts);
-                prevIndex += 1;
-                break;
-            case "dec":
-                throw new Error(
-                    `Row ${rowCounter}: dec is not supported after a chain row (flat row uses a backward walk)`
-                );
-            default:
-                throw new Error(`Unknown stitch type: ${stitch}`);
+        const secondParent = parentSeq[parentCursor + 1];
+        if (secondParent === undefined) {
+            throw rowErr(rowCounter, "dec requires 2 parent stitches");
         }
+        if (secondParent === firstParent) {
+            throw rowErr(
+                rowCounter,
+                "dec requires 2 distinct parent stitches; encountered a corner bounce repeat"
+            );
+        }
+        pushDecStitch(
+            nodes,
+            nodesBeforePrevRow + firstParent,
+            nodesBeforePrevRow + secondParent,
+            stitchOpts
+        );
+        parentCursor += 2;
     }
-    return prevIndex;
+    return parentCursor;
 }
 
 /** Physical parent indices 0..P-1 for each stitch: start at last (P-1), walk backward, bounce at ends repeating the corner stitch then reversing direction. */
@@ -250,16 +330,18 @@ function assertChainToLoopConsumesAllParentsExceptSkipped(
 ): void {
     for (const idx of parentLocal) {
         if (idx < 1 || idx >= P) {
-            throw new Error(
-                `Row ${rowCounter}: line-to-loop row must only attach to parents 1..${P - 1} (C0 skipped), got ${idx}`
+            throw rowErr(
+                rowCounter,
+                `line-to-loop row must only attach to parents 1..${P - 1} (C0 skipped), got ${idx}`
             );
         }
     }
     const used = new Set(parentLocal);
     for (let p = 1; p <= P - 1; p++) {
         if (!used.has(p)) {
-            throw new Error(
-                `Row ${rowCounter}: line-to-loop row must use every parent stitch from C1 to C${P - 1} (C0 skipped); missing parent index ${p}`
+            throw rowErr(
+                rowCounter,
+                `line-to-loop row must use every parent stitch from C1 to C${P - 1} (C0 skipped); missing parent index ${p}`
             );
         }
     }
@@ -267,19 +349,14 @@ function assertChainToLoopConsumesAllParentsExceptSkipped(
 
 function applyChainToLoopRow(
     row: string[],
-    ctx: {
-        nodes: PhysicsNode[];
-        nodesBeforePrevRow: number;
-        P: number;
-        rowCounter: number;
-        currentColor: string | undefined;
-    }
+    ctx: ChainToLoopRowContext
 ): void {
     const n = row.length;
-    const parentLocal = chainToLoopParentSequence(ctx.P);
+    const parentLocal = chainToLoopParentSequence(ctx.parentRowCount);
     if (parentLocal.length !== n) {
-        throw new Error(
-            `Row ${ctx.rowCounter}: line-to-loop row must have exactly ${parentLocal.length} stitches (2(P-1)), got ${n}`
+        throw rowErr(
+            ctx.rowCounter,
+            `line-to-loop row must have exactly ${parentLocal.length} stitches (2(P-1)), got ${n}`
         );
     }
     const { nodes, nodesBeforePrevRow, rowCounter, currentColor } = ctx;
@@ -287,32 +364,14 @@ function applyChainToLoopRow(
 
     for (let si = 0; si < n; si++) {
         const parentIndex = nodesBeforePrevRow + parentLocal[si];
-        const firstStitchInRow = si === 0;
-        const stitchOpts = {
-            firstStitchInRow,
-            lastNodeOfPrevRow: chainTipC0,
-            color: currentColor,
-        };
+        const stitchOpts = makeStitchOpts(si === 0, chainTipC0, currentColor);
 
-        const stitch = row[si];
-        const incChildren = parseIncChildCount(stitch);
-        if (incChildren !== null) {
-            pushIncStitch(nodes, parentIndex, incChildren, stitchOpts);
-            continue;
-        }
-        switch (stitch) {
-            case "sc":
-                pushScStitch(nodes, parentIndex, stitchOpts);
-                break;
-            case "dec":
-                throw new Error(
-                    `Row ${rowCounter}: dec is not supported in a line-to-loop closing round`
-                );
-            default:
-                throw new Error(`Unknown stitch type: ${stitch}`);
+        const consumedParents = applyScOrIncStitch(row[si], nodes, parentIndex, stitchOpts);
+        if (consumedParents === null) {
+            throw rowErr(rowCounter, "dec is not supported in a line-to-loop closing round");
         }
     }
-    assertChainToLoopConsumesAllParentsExceptSkipped(parentLocal, ctx.P, rowCounter);
+    assertChainToLoopConsumesAllParentsExceptSkipped(parentLocal, ctx.parentRowCount, rowCounter);
 }
 
 /** True when the row has more than one stitch and its first and last nodes are neighbors (closed ring). */
@@ -337,14 +396,8 @@ function tokenizeStitches(input: string, separator = ","): string[] {
         .filter(Boolean);
 }
 
-type ParsedLine =
-  | { type: "color"; value: string }
-  | { type: "row"; stitches: string[] }
-  | { type: "startMagicRing"; count: number }
-  | { type: "startChain"; count: number };
-
 function expandRowLine(line: string): string[] {
-    const tokens = line.toLowerCase().match(/\(|\)|,|[a-zA-Z]+x\d+|inc\d+|x|\d+|[a-zA-Z]+/g);
+    const tokens = line.toLowerCase().match(ROW_TOKEN_RE);
     if (!tokens || tokens.length === 0) {
         return [];
     }
@@ -414,11 +467,11 @@ function expandRowLine(line: string): string[] {
             continue;
         }
 
-        if (/^\d+$/.test(token)) {
+        if (UNEXPECTED_NUMBER_RE.test(token)) {
             throw new Error("Unexpected number in row");
         }
 
-        const singleStitchWithMultiplier = token.match(/^([a-zA-Z]+)x(\d+)$/);
+        const singleStitchWithMultiplier = token.match(SINGLE_STITCH_WITH_MULTIPLIER_RE);
         if (singleStitchWithMultiplier) {
             const stitch = singleStitchWithMultiplier[1];
             const count = Number(singleStitchWithMultiplier[2]);
@@ -456,12 +509,12 @@ function parsePatternLines(pattern: string): ParsedLine[] {
         }
 
         // color line (word or hex)
-        if (/^([a-zA-Z]+|#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}))$/.test(line)) {
+        if (COLOR_LINE_RE.test(line)) {
             result.push({ type: "color", value: line });
             continue;
         }
 
-        const mr = line.match(/^\s*mr\s*(\d+)\s*$/i);
+        const mr = line.match(MAGIC_RING_RE);
         if (mr) {
             const count = parseInt(mr[1], 10);
             if (count < 1) {
@@ -471,7 +524,7 @@ function parsePatternLines(pattern: string): ParsedLine[] {
             continue;
         }
 
-        const ch = line.match(/^\s*ch\s*(\d+)\s*$/i);
+        const ch = line.match(CHAIN_RE);
         if (ch) {
             const count = parseInt(ch[1], 10);
             if (count < 3) {
@@ -529,9 +582,7 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
             }
             const currentRowCount = nodes.length - currentRowCountStart;
             if (currentRowCount > 1) {
-                for (let i = 1; i < currentRowCount; i++) {
-                    connectNodes(nodes[currentRowCountStart + i - 1], nodes[currentRowCountStart + i]);
-                }
+                connectAdjacentNodesInRow(nodes, currentRowCountStart, currentRowCount);
                 connectNodes(nodes[currentRowCountStart], nodes[nodes.length - 1]);
             }
             nodesBeforePrevRow = currentRowCountStart;
@@ -547,9 +598,7 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
             }
             const currentRowCount = nodes.length - currentRowCountStart;
             if (currentRowCount > 1) {
-                for (let i = 1; i < currentRowCount; i++) {
-                    connectNodes(nodes[currentRowCountStart + i - 1], nodes[currentRowCountStart + i]);
-                }
+                connectAdjacentNodesInRow(nodes, currentRowCountStart, currentRowCount);
             }
             nodesBeforePrevRow = currentRowCountStart;
             prevRowCount = currentRowCount;
@@ -563,30 +612,35 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
         let prevIndex = 0;
 
         if (nodes.length === 0) {
-            throw new Error(
-                `Row ${rowCounter}: start with mr<number> or ch<number> (e.g. mr6 or ch6); optional color lines may come first`
+            throw rowErr(
+                rowCounter,
+                "start with mr<number> or ch<number> (e.g. mr6 or ch6); optional color lines may come first"
             );
         }
 
         {
             const parentWasLoopRound: boolean = prevRowWasLoopRound;
-            const P = prevRowCount;
-            const n = row.length;
+            const parentRowCount = prevRowCount;
+            const rowStitchCount = row.length;
+            const flatRowParentConsumption = parentConsumptionForRow(row, rowCounter);
 
             const isFirstRowAfterChain: boolean =
                 chainFoundationFirstNode !== null && !parentWasLoopRound;
 
             if (isFirstRowAfterChain) {
-                if (n !== P && n !== 2 * (P - 1)) {
-                    throw new Error(
-                        `Row ${rowCounter}: First row after a starting chain must have exactly P (${P}) stitches (flat line) or 2(P-1) (${2 * (P - 1)}) stitches (line to loop); got ${n}`
+                const isFlatFirstRowValid = flatRowParentConsumption === parentRowCount;
+                const isChainToLoopRowValid = rowStitchCount === 2 * (parentRowCount - 1);
+                if (!isFlatFirstRowValid && !isChainToLoopRowValid) {
+                    throw rowErr(
+                        rowCounter,
+                        `First row after a starting chain must consume exactly P (${parentRowCount}) parent stitches (flat line) or have exactly 2(P-1) (${2 * (parentRowCount - 1)}) stitches (line to loop); got ${rowStitchCount} stitches consuming ${flatRowParentConsumption} parents`
                     );
                 }
             }
 
             /** First working row after `ch` with N = 2(P−1) closes the chain into a loop. */
             const isChainToLoopRound: boolean =
-                isFirstRowAfterChain && n === 2 * (P - 1);
+                isFirstRowAfterChain && rowStitchCount === 2 * (parentRowCount - 1);
 
             const lastNodeOfPrevRow = nodes[nodesBeforePrevRow + prevRowCount - 1];
 
@@ -603,14 +657,14 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
                 applyChainToLoopRow(row, {
                     nodes,
                     nodesBeforePrevRow,
-                    P,
+                    parentRowCount,
                     rowCounter,
                     currentColor,
                 });
             } else {
-                const parentSeq = flatLineParentSequence(P, n);
-                if (parentSeq.length !== n) {
-                    throw new Error(`Row ${rowCounter}: invalid line parent sequence`);
+                const parentSeq = flatLineParentSequence(parentRowCount, flatRowParentConsumption);
+                if (parentSeq.length !== flatRowParentConsumption) {
+                    throw rowErr(rowCounter, "invalid line parent sequence");
                 }
                 prevIndex = processFlatLineRow(row, parentSeq, {
                     nodes,
@@ -625,14 +679,16 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
 
             if (parentWasLoopRound) {
                 if (prevIndex !== prevRowCount) {
-                    throw new Error(
-                        `Row ${rowCounter}: Expected to consume ${prevRowCount} parent stitches, but consumed ${prevIndex}`
+                    throw rowErr(
+                        rowCounter,
+                        `Expected to consume ${prevRowCount} parent stitches, but consumed ${prevIndex}`
                     );
                 }
             } else if (!isChainToLoopRound) {
-                if (prevIndex !== n) {
-                    throw new Error(
-                        `Row ${rowCounter}: Expected ${n} stitches in this row, but processed ${prevIndex}`
+                if (prevIndex !== flatRowParentConsumption) {
+                    throw rowErr(
+                        rowCounter,
+                        `Expected to consume ${flatRowParentConsumption} parent stitches in this row, but consumed ${prevIndex}`
                     );
                 }
             }
@@ -641,9 +697,7 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
         const currentRowCount = nodes.length - currentRowCountStart;
 
         if (currentRowCount > 1) {
-            for (let i = 1; i < currentRowCount; i++) {
-                connectNodes(nodes[currentRowCountStart + i - 1], nodes[currentRowCountStart + i]);
-            }
+            connectAdjacentNodesInRow(nodes, currentRowCountStart, currentRowCount);
         }
 
         // Do not connect chain tip C0 to the first sc on flat rows — that edge closes a loop around the foundation.

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -5,6 +5,183 @@ function connectNodes(n1: PhysicsNode, n2: PhysicsNode) {
     if (!n2.neighbors.includes(n1)) n2.neighbors.push(n1);
 }
 
+type StitchAttachmentOpts = {
+    firstStitchInRow: boolean;
+    /** End of the previous row in stitch order — models yarn running from there to the first stitch of this row. */
+    lastNodeOfPrevRow: PhysicsNode;
+    color?: string;
+};
+
+function pushScStitch(
+    nodes: PhysicsNode[],
+    parentIndex: number,
+    opts: StitchAttachmentOpts
+): void {
+    const nodeIndex = nodes.length;
+    nodes.push(new PhysicsNode(opts.color));
+    connectNodes(nodes[nodeIndex], nodes[parentIndex]);
+    if (opts.firstStitchInRow) {
+        connectNodes(nodes[nodeIndex], opts.lastNodeOfPrevRow);
+    }
+}
+
+/**
+ * Increase: `childCount` new stitches (default 2 for plain `inc`), all into the same parent.
+ * Adjacent new stitches are linked in row order by the caller's within-row chain pass.
+ */
+function pushIncStitch(
+    nodes: PhysicsNode[],
+    parentIndex: number,
+    childCount: number,
+    opts: StitchAttachmentOpts
+): void {
+    if (childCount < 2) {
+        throw new Error(`Increase must add at least 2 stitches, got ${childCount}`);
+    }
+    const startIndex = nodes.length;
+    for (let k = 0; k < childCount; k++) {
+        nodes.push(new PhysicsNode(opts.color));
+    }
+    for (let k = 0; k < childCount; k++) {
+        connectNodes(nodes[startIndex + k], nodes[parentIndex]);
+    }
+    if (opts.firstStitchInRow) {
+        connectNodes(nodes[startIndex], opts.lastNodeOfPrevRow);
+    }
+}
+
+/** `inc` → 2 children; `inc3` / `inc4` → that many children. Returns null if not an increase stitch. */
+function parseIncChildCount(stitch: string): number | null {
+    if (stitch === "inc") {
+        return 2;
+    }
+    const m = stitch.match(/^inc(\d+)$/);
+    if (!m) {
+        return null;
+    }
+    const n = parseInt(m[1], 10);
+    if (!Number.isInteger(n) || n < 2) {
+        throw new Error(`Increase must add at least 2 stitches (e.g. inc or inc3); got "${stitch}"`);
+    }
+    return n;
+}
+
+function pushDecStitch(
+    nodes: PhysicsNode[],
+    parentIndex1: number,
+    parentIndex2: number,
+    opts: StitchAttachmentOpts
+): void {
+    const nodeIndex = nodes.length;
+    nodes.push(new PhysicsNode(opts.color));
+    connectNodes(nodes[nodeIndex], nodes[parentIndex1]);
+    connectNodes(nodes[nodeIndex], nodes[parentIndex2]);
+    if (opts.firstStitchInRow) {
+        connectNodes(nodes[nodeIndex], opts.lastNodeOfPrevRow);
+    }
+}
+
+type LoopRowContext = {
+    nodes: PhysicsNode[];
+    nodesBeforePrevRow: number;
+    prevRowCount: number;
+    rowCounter: number;
+    currentColor: string | undefined;
+    lastNodeOfPrevRow: PhysicsNode;
+};
+
+function processLoopRoundRow(row: string[], ctx: LoopRowContext): number {
+    let prevIndex = 0;
+    const { nodes, nodesBeforePrevRow, prevRowCount, rowCounter, currentColor, lastNodeOfPrevRow } = ctx;
+
+    for (const stitch of row) {
+        const firstStitchInRow = prevIndex === 0;
+        const stitchOpts = { firstStitchInRow, lastNodeOfPrevRow, color: currentColor };
+
+        const incChildren = parseIncChildCount(stitch);
+        if (incChildren !== null) {
+            if (prevIndex >= prevRowCount) {
+                throw new Error(`Row ${rowCounter}: Not enough parent stitches`);
+            }
+            pushIncStitch(nodes, nodesBeforePrevRow + prevIndex, incChildren, stitchOpts);
+            prevIndex += 1;
+            continue;
+        }
+
+        switch (stitch) {
+            case "sc": {
+                if (prevIndex >= prevRowCount) {
+                    throw new Error(`Row ${rowCounter}: Not enough parent stitches`);
+                }
+                pushScStitch(nodes, nodesBeforePrevRow + prevIndex, stitchOpts);
+                prevIndex += 1;
+                break;
+            }
+            case "dec": {
+                if (prevIndex + 1 >= prevRowCount) {
+                    throw new Error(`Row ${rowCounter}: dec requires 2 parent stitches`);
+                }
+                pushDecStitch(
+                    nodes,
+                    nodesBeforePrevRow + prevIndex,
+                    nodesBeforePrevRow + prevIndex + 1,
+                    stitchOpts
+                );
+                prevIndex += 2;
+                break;
+            }
+            default:
+                throw new Error(`Unknown stitch type: ${stitch}`);
+        }
+    }
+    return prevIndex;
+}
+
+type FlatLineRowContext = {
+    nodes: PhysicsNode[];
+    nodesBeforePrevRow: number;
+    rowCounter: number;
+    currentColor: string | undefined;
+    lastNodeOfPrevRow: PhysicsNode;
+};
+
+function processFlatLineRow(row: string[], parentSeq: number[], ctx: FlatLineRowContext): number {
+    let prevIndex = 0;
+    const { nodes, nodesBeforePrevRow, rowCounter, currentColor, lastNodeOfPrevRow } = ctx;
+
+    for (const stitch of row) {
+        const firstStitchInRow = prevIndex === 0;
+        const physicalParent = parentSeq[prevIndex];
+        const stitchOpts: StitchAttachmentOpts = {
+            firstStitchInRow,
+            lastNodeOfPrevRow,
+            color: currentColor,
+        };
+        const parentIndex = nodesBeforePrevRow + physicalParent;
+
+        const incChildren = parseIncChildCount(stitch);
+        if (incChildren !== null) {
+            pushIncStitch(nodes, parentIndex, incChildren, stitchOpts);
+            prevIndex += 1;
+            continue;
+        }
+
+        switch (stitch) {
+            case "sc":
+                pushScStitch(nodes, parentIndex, stitchOpts);
+                prevIndex += 1;
+                break;
+            case "dec":
+                throw new Error(
+                    `Row ${rowCounter}: dec is not supported after a chain row (flat row uses a backward walk)`
+                );
+            default:
+                throw new Error(`Unknown stitch type: ${stitch}`);
+        }
+    }
+    return prevIndex;
+}
+
 /** Physical parent indices 0..P-1 for each stitch: start at last (P-1), walk backward, bounce at ends repeating the corner stitch then reversing direction. */
 function lineParentSequence(P: number, n: number): number[] {
     if (P < 1 || n < 1) {
@@ -35,6 +212,20 @@ function lineParentSequence(P: number, n: number): number[] {
         pos = nextPos;
     }
     return seq;
+}
+
+/**
+ * Flat line rows: parent indices run P−1, P−2, … for each stitch (no “return” along the row like a loop).
+ * When n ≤ P this is exactly [P−1, …, P−n]. When n > P, reuse the bouncing walk from `lineParentSequence`.
+ */
+function flatLineParentSequence(P: number, n: number): number[] {
+    if (P < 1 || n < 1) {
+        return [];
+    }
+    if (n <= P) {
+        return Array.from({ length: n }, (_, i) => P - 1 - i);
+    }
+    return lineParentSequence(P, n);
 }
 
 /**
@@ -74,6 +265,56 @@ function assertChainToLoopConsumesAllParentsExceptSkipped(
     }
 }
 
+function applyChainToLoopRow(
+    row: string[],
+    ctx: {
+        nodes: PhysicsNode[];
+        nodesBeforePrevRow: number;
+        P: number;
+        rowCounter: number;
+        currentColor: string | undefined;
+    }
+): void {
+    const n = row.length;
+    const parentLocal = chainToLoopParentSequence(ctx.P);
+    if (parentLocal.length !== n) {
+        throw new Error(
+            `Row ${ctx.rowCounter}: line-to-loop row must have exactly ${parentLocal.length} stitches (2(P-1)), got ${n}`
+        );
+    }
+    const { nodes, nodesBeforePrevRow, rowCounter, currentColor } = ctx;
+    const chainTipC0 = nodes[nodesBeforePrevRow];
+
+    for (let si = 0; si < n; si++) {
+        const parentIndex = nodesBeforePrevRow + parentLocal[si];
+        const firstStitchInRow = si === 0;
+        const stitchOpts = {
+            firstStitchInRow,
+            lastNodeOfPrevRow: chainTipC0,
+            color: currentColor,
+        };
+
+        const stitch = row[si];
+        const incChildren = parseIncChildCount(stitch);
+        if (incChildren !== null) {
+            pushIncStitch(nodes, parentIndex, incChildren, stitchOpts);
+            continue;
+        }
+        switch (stitch) {
+            case "sc":
+                pushScStitch(nodes, parentIndex, stitchOpts);
+                break;
+            case "dec":
+                throw new Error(
+                    `Row ${rowCounter}: dec is not supported in a line-to-loop closing round`
+                );
+            default:
+                throw new Error(`Unknown stitch type: ${stitch}`);
+        }
+    }
+    assertChainToLoopConsumesAllParentsExceptSkipped(parentLocal, ctx.P, rowCounter);
+}
+
 /** True when the row has more than one stitch and its first and last nodes are neighbors (closed ring). */
 export function rowFirstAndLastAreNeighbors(
     nodes: PhysicsNode[],
@@ -103,7 +344,7 @@ type ParsedLine =
   | { type: "startChain"; count: number };
 
 function expandRowLine(line: string): string[] {
-    const tokens = line.toLowerCase().match(/\(|\)|,|[a-zA-Z]+x\d+|x|\d+|[a-zA-Z]+/g);
+    const tokens = line.toLowerCase().match(/\(|\)|,|[a-zA-Z]+x\d+|inc\d+|x|\d+|[a-zA-Z]+/g);
     if (!tokens || tokens.length === 0) {
         return [];
     }
@@ -229,8 +470,10 @@ function parsePatternLines(pattern: string): ParsedLine[] {
         const ch = line.match(/^\s*ch\s*(\d+)\s*$/i);
         if (ch) {
             const count = parseInt(ch[1], 10);
-            if (count < 1) {
-                throw new Error("Chain stitch count must be at least 1");
+            if (count < 3) {
+                throw new Error(
+                    "Chain stitch count must be at least 3 (shorter chains make P vs 2(P-1) ambiguous on the first row)"
+                );
             }
             result.push({ type: "startChain", count });
             continue;
@@ -314,7 +557,6 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
         const row = entry.stitches;
         const currentRowCountStart = nodes.length;
         let prevIndex = 0;
-        let attachChainTipToFirstStitch = false;
 
         if (nodes.length === 0) {
             throw new Error(
@@ -327,156 +569,55 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
             const P = prevRowCount;
             const n = row.length;
 
-            /** Only all-sc rows can close a chain into a loop (avoid (sc,inc)x2 matching n = 2(P-1) by accident). */
-            const isChainToLoopRound: boolean =
-                !parentWasLoopRound &&
-                P >= 2 &&
-                n === 2 * (P - 1) &&
-                row.every((s: string) => s === "sc");
+            const isFirstRowAfterChain: boolean =
+                chainFoundationFirstNode !== null && !parentWasLoopRound;
 
-            const lastNodeOfPrevRow = nodes[nodesBeforePrevRow + prevRowCount - 1];
-
-            const processStitchAlongParentsLoop = (stitch: string) => {
-                const firstStitchInRow = prevIndex === 0;
-                switch (stitch) {
-                    case "sc": {
-                        if (prevIndex >= prevRowCount) {
-                            throw new Error(`Row ${rowCounter}: Not enough parent stitches`);
-                        }
-                        const nodeIndex = nodes.length;
-                        const parentIndex = nodesBeforePrevRow + prevIndex;
-
-                        nodes.push(new PhysicsNode(currentColor));
-                        connectNodes(nodes[nodeIndex], nodes[parentIndex]);
-                        if (firstStitchInRow) {
-                            connectNodes(nodes[nodeIndex], lastNodeOfPrevRow);
-                        }
-
-                        prevIndex += 1;
-                        break;
-                    }
-
-                    case "inc": {
-                        if (prevIndex >= prevRowCount) {
-                            throw new Error(`Row ${rowCounter}: Not enough parent stitches`);
-                        }
-                        const parentIndex = nodesBeforePrevRow + prevIndex;
-
-                        const nodeIndex1 = nodes.length;
-                        const nodeIndex2 = nodes.length + 1;
-
-                        nodes.push(new PhysicsNode(currentColor), new PhysicsNode(currentColor));
-
-                        connectNodes(nodes[nodeIndex1], nodes[parentIndex]);
-                        connectNodes(nodes[nodeIndex2], nodes[parentIndex]);
-                        if (firstStitchInRow) {
-                            connectNodes(nodes[nodeIndex1], lastNodeOfPrevRow);
-                        }
-
-                        prevIndex += 1;
-                        break;
-                    }
-
-                    case "dec": {
-                        if (prevIndex + 1 >= prevRowCount) {
-                            throw new Error(`Row ${rowCounter}: dec requires 2 parent stitches`);
-                        }
-                        const parentIndex1 = nodesBeforePrevRow + prevIndex;
-                        const parentIndex2 = nodesBeforePrevRow + prevIndex + 1;
-                        const nodeIndex = nodes.length;
-
-                        nodes.push(new PhysicsNode(currentColor));
-
-                        connectNodes(nodes[nodeIndex], nodes[parentIndex1]);
-                        connectNodes(nodes[nodeIndex], nodes[parentIndex2]);
-                        if (firstStitchInRow) {
-                            connectNodes(nodes[nodeIndex], lastNodeOfPrevRow);
-                        }
-
-                        prevIndex += 2;
-                        break;
-                    }
-
-                    default:
-                        throw new Error(`Unknown stitch type: ${stitch}`);
-                }
-            };
-
-            if (parentWasLoopRound) {
-                for (const stitch of row) {
-                    processStitchAlongParentsLoop(stitch);
-                }
-            } else {
-                if (isChainToLoopRound) {
-                    const parentLocal = chainToLoopParentSequence(P);
-                    if (parentLocal.length !== n) {
-                        throw new Error(
-                            `Row ${rowCounter}: line-to-loop row must have exactly ${parentLocal.length} stitches (2(P-1)), got ${n}`
-                        );
-                    }
-                    for (let si = 0; si < n; si++) {
-                        const nodeIndex = nodes.length;
-                        const parentIndex = nodesBeforePrevRow + parentLocal[si];
-                        nodes.push(new PhysicsNode(currentColor));
-                        connectNodes(nodes[nodeIndex], nodes[parentIndex]);
-                        if (si === 0) {
-                            connectNodes(nodes[nodeIndex], nodes[nodesBeforePrevRow]);
-                        }
-                    }
-                    assertChainToLoopConsumesAllParentsExceptSkipped(parentLocal, P, rowCounter);
-                } else {
-                    const parentSeq = lineParentSequence(P, n);
-                    if (parentSeq.length !== n) {
-                        throw new Error(`Row ${rowCounter}: invalid line parent sequence`);
-                    }
-                    const processStitchAlongParentsLine = (stitch: string) => {
-                        const firstStitchInRow = prevIndex === 0;
-                        const physicalParent = parentSeq[prevIndex];
-                        switch (stitch) {
-                            case "sc": {
-                                const nodeIndex = nodes.length;
-                                const parentIndex = nodesBeforePrevRow + physicalParent;
-                                nodes.push(new PhysicsNode(currentColor));
-                                connectNodes(nodes[nodeIndex], nodes[parentIndex]);
-                                if (firstStitchInRow) {
-                                    connectNodes(nodes[nodeIndex], lastNodeOfPrevRow);
-                                }
-                                prevIndex += 1;
-                                break;
-                            }
-                            case "inc": {
-                                const parentIndex = nodesBeforePrevRow + physicalParent;
-                                const nodeIndex1 = nodes.length;
-                                const nodeIndex2 = nodes.length + 1;
-                                nodes.push(new PhysicsNode(currentColor), new PhysicsNode(currentColor));
-                                connectNodes(nodes[nodeIndex1], nodes[parentIndex]);
-                                connectNodes(nodes[nodeIndex2], nodes[parentIndex]);
-                                if (firstStitchInRow) {
-                                    connectNodes(nodes[nodeIndex1], lastNodeOfPrevRow);
-                                }
-                                prevIndex += 1;
-                                break;
-                            }
-                            case "dec":
-                                throw new Error(
-                                    `Row ${rowCounter}: dec is not supported after a chain row (flat row uses a backward walk)`
-                                );
-                            default:
-                                throw new Error(`Unknown stitch type: ${stitch}`);
-                        }
-                    };
-                    for (const stitch of row) {
-                        processStitchAlongParentsLine(stitch);
-                    }
+            if (isFirstRowAfterChain) {
+                if (n !== P && n !== 2 * (P - 1)) {
+                    throw new Error(
+                        `Row ${rowCounter}: First row after a starting chain must have exactly P (${P}) stitches (flat line) or 2(P-1) (${2 * (P - 1)}) stitches (line to loop); got ${n}`
+                    );
                 }
             }
 
-            prevRowWasLoopRound = parentWasLoopRound || isChainToLoopRound;
+            /** First working row after `ch` with N = 2(P−1) closes the chain into a loop. */
+            const isChainToLoopRound: boolean =
+                isFirstRowAfterChain && n === 2 * (P - 1);
 
-            attachChainTipToFirstStitch =
-                chainFoundationFirstNode !== null &&
-                !parentWasLoopRound &&
-                !isChainToLoopRound;
+            const lastNodeOfPrevRow = nodes[nodesBeforePrevRow + prevRowCount - 1];
+
+            if (parentWasLoopRound) {
+                prevIndex = processLoopRoundRow(row, {
+                    nodes,
+                    nodesBeforePrevRow,
+                    prevRowCount,
+                    rowCounter,
+                    currentColor,
+                    lastNodeOfPrevRow,
+                });
+            } else if (isChainToLoopRound) {
+                applyChainToLoopRow(row, {
+                    nodes,
+                    nodesBeforePrevRow,
+                    P,
+                    rowCounter,
+                    currentColor,
+                });
+            } else {
+                const parentSeq = flatLineParentSequence(P, n);
+                if (parentSeq.length !== n) {
+                    throw new Error(`Row ${rowCounter}: invalid line parent sequence`);
+                }
+                prevIndex = processFlatLineRow(row, parentSeq, {
+                    nodes,
+                    nodesBeforePrevRow,
+                    rowCounter,
+                    currentColor,
+                    lastNodeOfPrevRow,
+                });
+            }
+
+            prevRowWasLoopRound = parentWasLoopRound || isChainToLoopRound;
 
             if (parentWasLoopRound) {
                 if (prevIndex !== prevRowCount) {
@@ -501,10 +642,8 @@ export const createParsedGraph = (pattern: string): { nodes: PhysicsNode[]; last
             }
         }
 
+        // Do not connect chain tip C0 to the first sc on flat rows — that edge closes a loop around the foundation.
         if (chainFoundationFirstNode !== null) {
-            if (attachChainTipToFirstStitch && currentRowCount > 0) {
-                connectNodes(nodes[chainFoundationFirstNode], nodes[currentRowCountStart]);
-            }
             chainFoundationFirstNode = null;
         }
 

--- a/frontend/src/utilities/parser.ts
+++ b/frontend/src/utilities/parser.ts
@@ -17,6 +17,109 @@ type ParsedLine =
   | { type: "color"; value: string }
   | { type: "row"; stitches: string[] };
 
+function expandRowLine(line: string): string[] {
+    const tokens = line.toLowerCase().match(/\(|\)|,|[a-zA-Z]+x\d+|x|\d+|[a-zA-Z]+/g);
+    if (!tokens || tokens.length === 0) {
+        return [];
+    }
+
+    const stitches: string[] = [];
+    const groupStarts: number[] = [];
+    let lastSingleStitchIndex: number | null = null;
+
+    for (let i = 0; i < tokens.length; i++) {
+        const token = tokens[i];
+
+        if (token === ",") {
+            lastSingleStitchIndex = null;
+            continue;
+        }
+
+        if (token === "(") {
+            groupStarts.push(stitches.length);
+            lastSingleStitchIndex = null;
+            continue;
+        }
+
+        if (token === ")") {
+            if (groupStarts.length === 0) {
+                throw new Error("Unmatched closing parenthesis in row");
+            }
+
+            const xToken = tokens[i + 1];
+            const countToken = tokens[i + 2];
+            const count = Number(countToken);
+
+            if (xToken !== "x" || !Number.isInteger(count) || count < 1) {
+                throw new Error("Parenthesized group must be followed by x and a positive integer");
+            }
+
+            const groupStart = groupStarts.pop() as number;
+            const group = stitches.slice(groupStart);
+            stitches.length = groupStart;
+
+            for (let j = 0; j < count; j++) {
+                stitches.push(...group);
+            }
+
+            i += 2;
+            lastSingleStitchIndex = null;
+            continue;
+        }
+
+        if (token === "x") {
+            const countToken = tokens[i + 1];
+            const count = Number(countToken);
+
+            if (!Number.isInteger(count) || count < 1) {
+                throw new Error("Single stitch multiplier must use x and a positive integer");
+            }
+            if (lastSingleStitchIndex === null) {
+                throw new Error("Single stitch multiplier x must follow a stitch");
+            }
+
+            const stitch = stitches[lastSingleStitchIndex];
+            for (let j = 1; j < count; j++) {
+                stitches.push(stitch);
+            }
+
+            i += 1;
+            lastSingleStitchIndex = null;
+            continue;
+        }
+
+        if (/^\d+$/.test(token)) {
+            throw new Error("Unexpected number in row");
+        }
+
+        const singleStitchWithMultiplier = token.match(/^([a-zA-Z]+)x(\d+)$/);
+        if (singleStitchWithMultiplier) {
+            const stitch = singleStitchWithMultiplier[1];
+            const count = Number(singleStitchWithMultiplier[2]);
+
+            if (!Number.isInteger(count) || count < 1) {
+                throw new Error("Single stitch multiplier must use x and a positive integer");
+            }
+
+            for (let j = 0; j < count; j++) {
+                stitches.push(stitch);
+            }
+
+            lastSingleStitchIndex = null;
+            continue;
+        }
+
+        stitches.push(token);
+        lastSingleStitchIndex = stitches.length - 1;
+    }
+
+    if (groupStarts.length > 0) {
+        throw new Error("Unclosed parenthesis in row");
+    }
+
+    return stitches;
+}
+
 function parsePatternLines(pattern: string): ParsedLine[] {
     const lines = tokenizeStitches(pattern, "\n");
     const result: ParsedLine[] = [];
@@ -28,25 +131,9 @@ function parsePatternLines(pattern: string): ParsedLine[] {
             continue;
         }
 
-        // whether the line matches the form: (something) x number
-        const match = line.match(/^\(([^)]+)\)\s*x\s*(\d+)$/i);
-
-        if (match) {
-            const group = match[1];
-            const count = parseInt(match[2], 10);
-            const stitches = tokenizeStitches(group);
-
-            const expanded: string[] = [];
-            for (let i = 0; i < count; i++) {
-                expanded.push(...stitches);
-            }
-            result.push({ type: "row", stitches: expanded });
-        } else {
-            // already expanded row
-            const stitches = tokenizeStitches(line);
-            if (stitches.length > 0) {
-                result.push({ type: "row", stitches });
-            }
+        const stitches = expandRowLine(line);
+        if (stitches.length > 0) {
+            result.push({ type: "row", stitches });
         }
     }
     return result;

--- a/frontend/src/utilities/patternTextComments.ts
+++ b/frontend/src/utilities/patternTextComments.ts
@@ -1,0 +1,59 @@
+/** Toggle `// ` after leading whitespace (VS Code–style line comment). */
+export function toggleOneLineComment(line: string): string {
+    const m = line.match(/^(\s*)(.*)$/);
+    if (!m) return line;
+    const indent = m[1];
+    let rest = m[2];
+    if (rest.startsWith("//")) {
+        rest = rest.slice(2);
+        if (rest.startsWith(" ")) rest = rest.slice(1);
+        return indent + rest;
+    }
+    return indent + "// " + rest;
+}
+
+export function toggleCommentAtSelection(
+    value: string,
+    selectionStart: number,
+    selectionEnd: number
+): { text: string; selectionStart: number; selectionEnd: number } {
+    const oldLines = value.split("\n");
+    const startLine = value.slice(0, selectionStart).split("\n").length - 1;
+    const endLine = value.slice(0, selectionEnd).split("\n").length - 1;
+
+    const newLines = oldLines.map((line, i) =>
+        i >= startLine && i <= endLine ? toggleOneLineComment(line) : line
+    );
+    const text = newLines.join("\n");
+
+    const mapOffset = (oldOffset: number): number => {
+        const lineIdx = value.slice(0, oldOffset).split("\n").length - 1;
+        const lineStartOld = oldOffset === 0 ? 0 : value.lastIndexOf("\n", oldOffset - 1) + 1;
+        const col = oldOffset - lineStartOld;
+        const oldLine = oldLines[lineIdx];
+        const newLine = newLines[lineIdx];
+        const indent = /^(\s*)/.exec(oldLine)?.[1] ?? "";
+        const delta = newLine.length - oldLine.length;
+
+        let pos = 0;
+        for (let i = 0; i < lineIdx; i++) {
+            pos += newLines[i].length + 1;
+        }
+        if (lineIdx >= startLine && lineIdx <= endLine) {
+            if (col <= indent.length) {
+                pos += col;
+            } else {
+                pos += col + delta;
+            }
+        } else {
+            pos += col;
+        }
+        return pos;
+    };
+
+    return {
+        text,
+        selectionStart: mapOffset(selectionStart),
+        selectionEnd: mapOffset(selectionEnd),
+    };
+}


### PR DESCRIPTION
Hi Jeongwon. This PR ended up being more complicated than I hoped, but it's working pretty well now. I still want to do some cleanup, but I had to make some decisions about the parser, so I'm writing them down now.
- Now patterns always start with a magic ring (mr6) or a linear chain (ch6)
- Ring patterns are actually converted into spiral shapes instead of uniform rows now (more realistic)
- Chain starts can continually zigzag (in rows) or turn into loops (in spiral)
- Going from chain to loop was a huge pain in the ass
- I assumed that the first looping row always starts in second stitch, skipping the first, goes to the end, and comes back
- The number of stitches fits `N = 2 * (P - 1)`, where P is the number of stitches in the previous row
- There's no skip in rows, so N = P, but you can still use `inc` and `dec` to get narrower and wider
- I also added support for 3 sc in same stitch, but I shortened it to inc3 (should work for other numbers too)